### PR TITLE
Added an extra 5 second delayed check if first server support check fails

### DIFF
--- a/src/main/java/net/kyrptonaught/inventorysorter/client/InventorySorterModClient.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/client/InventorySorterModClient.java
@@ -65,21 +65,24 @@ public class InventorySorterModClient implements ClientModInitializer {
 
 
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+            serverIsPresent = false;
             scheduler = Executors.newSingleThreadScheduledExecutor();
 
             ClientPlayNetworking.send(new ClientSync(true));
             syncConfig();
 
+            // Two-stage check: first at 5 seconds, then at 10 seconds if still no server
             scheduler.schedule(() -> {
                 if (!serverIsPresent) {
-                    client.execute(() -> {
-                        if (client.player != null) {
+                    // First check at 5 seconds - schedule another check at 10 seconds
+                    scheduler.schedule(() -> {
+                        if (!serverIsPresent && client.player != null) {
                             client.player.sendMessage(
                                     Text.literal("[Inventory Sorter] ").styled(style -> style.withBold(true).withColor(Formatting.AQUA))
                                             .append(Text.translatable("inventorysorter.warning.missing-server").styled(style -> style.withBold(false).withColor(Formatting.YELLOW))
                                             ), false);
                         }
-                    });
+                    }, 5, TimeUnit.SECONDS);
                 }
             }, 5, TimeUnit.SECONDS);
         });

--- a/src/main/java/net/kyrptonaught/inventorysorter/network/ServerPresencePacket.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/network/ServerPresencePacket.java
@@ -9,7 +9,7 @@ import static net.kyrptonaught.inventorysorter.InventorySorterMod.MOD_ID;
 
 public record ServerPresencePacket() implements CustomPayload {
 
-    public static final Id<ServerPresencePacket> ID = new Id<>(Identifier.of(MOD_ID, "client_sync_packet"));
+    public static final Id<ServerPresencePacket> ID = new Id<>(Identifier.of(MOD_ID, "server_presence_packet"));
     public static final ServerPresencePacket DEFAULT = new ServerPresencePacket();
 
     public static final PacketCodec<RegistryByteBuf, ServerPresencePacket> CODEC =


### PR DESCRIPTION
On macOS it was always failing for some reason, leading to "server support not detected" every time even if it was supported. The check was happening before we received packets from the server. I think macOS must have some networking differences.

Either way, the server support detection is now much more robust.