### PR TITLE
Fix client-side sorting when partial stacks need to merge (Video Included)

### DIFF
--- a/src/main/java/net/kyrptonaught/inventorysorter/client/sort/plan/ClickPlanningState.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/client/sort/plan/ClickPlanningState.java
@@ -80,29 +80,19 @@ final class ClickPlanningState {
         return -1;
     }
 
-    int findMergeOrigin(ItemStack desiredStack, int target) {
+    int findAvailableMergeStack(ItemStack desiredStack, int excludedSlot, boolean[] reservedSlots) {
         for (int i = 0; i < simulated.size(); i++) {
-            if (canUseAsMergeOrigin(i, target, desiredStack)) {
+            if (i != excludedSlot
+                    && !reservedSlots[i]
+                    && SortableItemStackRules.canMergeToward(simulated.get(i), desiredStack)) {
                 return i;
             }
         }
         return -1;
     }
 
-    int findMergeOrigin(ItemStack desiredStack, int target, boolean[] reservedSlots) {
-        for (int i = 0; i < simulated.size(); i++) {
-            if (!reservedSlots[i] && canUseAsMergeOrigin(i, target, desiredStack)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    private boolean canUseAsMergeOrigin(int slot, int target, ItemStack desiredStack) {
-        return slot != target
-                && SortableItemStackRules.canMergeToward(simulated.get(slot), desiredStack)
-                && simulated.get(slot).getCount() < simulated.get(slot).getMaxStackSize()
-                && !SortableItemStackRules.sameLayoutStack(simulated.get(slot), desired.get(slot));
+    boolean stackMatches(int slot, ItemStack desiredStack) {
+        return SortableItemStackRules.sameLayoutStack(simulated.get(slot), desiredStack);
     }
 
     void moveStack(int origin, int target) {

--- a/src/main/java/net/kyrptonaught/inventorysorter/client/sort/plan/MergePlanningPass.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/client/sort/plan/MergePlanningPass.java
@@ -6,47 +6,66 @@ import net.minecraft.world.item.ItemStack;
 final class MergePlanningPass {
     boolean plan(ClickPlanningState state) {
         boolean[] reservedExactSlots = new boolean[state.size()];
+        boolean[] preparedTargets = new boolean[state.size()];
+
+        reserveExistingExactStacks(state, reservedExactSlots, preparedTargets);
+
         for (int target = 0; target < state.size(); target++) {
-            if (!planTarget(state, target, reservedExactSlots)) {
+            if (!prepareMergedStack(state, target, reservedExactSlots, preparedTargets)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean planTarget(ClickPlanningState state, int target, boolean[] reservedExactSlots) {
+    private void reserveExistingExactStacks(
+            ClickPlanningState state,
+            boolean[] reservedExactSlots,
+            boolean[] preparedTargets
+    ) {
+        for (int target = 0; target < state.size(); target++) {
+            ItemStack desiredStack = state.desiredStack(target);
+            if (desiredStack.isEmpty()) {
+                continue;
+            }
+
+            int exactSlot = state.findMatchingSlot(desiredStack, 0, reservedExactSlots);
+            if (exactSlot != -1) {
+                reservedExactSlots[exactSlot] = true;
+                preparedTargets[target] = true;
+            }
+        }
+    }
+
+    private boolean prepareMergedStack(
+            ClickPlanningState state,
+            int target,
+            boolean[] reservedExactSlots,
+            boolean[] preparedTargets
+    ) {
         ItemStack desiredStack = state.desiredStack(target);
-        if (desiredStack.isEmpty()) {
+        if (desiredStack.isEmpty() || preparedTargets[target]) {
             return true;
         }
 
-        if (state.targetAlreadyMatches(target)) {
-            reservedExactSlots[target] = true;
-            return true;
+        int accumulator = state.findAvailableMergeStack(desiredStack, -1, reservedExactSlots);
+        if (accumulator == -1 || state.simulatedStack(accumulator).getCount() > desiredStack.getCount()) {
+            return false;
         }
 
-        int exactOrigin = state.findMatchingSlot(desiredStack, target + 1, reservedExactSlots);
-        if (exactOrigin != -1) {
-            reservedExactSlots[exactOrigin] = true;
-            return true;
-        }
-
-        if (state.simulatedStack(target).isEmpty()) {
-            int origin = state.findMergeOrigin(desiredStack, target, reservedExactSlots);
+        while (needsMoreOfDesiredStack(state, desiredStack, accumulator)) {
+            int origin = state.findAvailableMergeStack(desiredStack, accumulator, reservedExactSlots);
             if (origin == -1) {
                 return false;
             }
-            state.moveStack(origin, target);
+            state.mergeStack(origin, accumulator);
         }
 
-        while (needsMoreOfDesiredStack(state, desiredStack, target)) {
-            int origin = state.findMergeOrigin(desiredStack, target, reservedExactSlots);
-            if (origin == -1) {
-                return false;
-            }
-            state.mergeStack(origin, target);
+        boolean prepared = state.stackMatches(accumulator, desiredStack);
+        if (prepared) {
+            reservedExactSlots[accumulator] = true;
         }
-        return true;
+        return prepared;
     }
 
     private boolean needsMoreOfDesiredStack(ClickPlanningState state, ItemStack desiredStack, int target) {

--- a/src/test/java/net/kyrptonaught/inventorysorter/client/sort/ClientSortClickPlannerTest.java
+++ b/src/test/java/net/kyrptonaught/inventorysorter/client/sort/ClientSortClickPlannerTest.java
@@ -3,6 +3,8 @@ package net.kyrptonaught.inventorysorter.client.sort;
 import net.kyrptonaught.inventorysorter.client.sort.plan.ClientSortClickPlanner;
 import net.kyrptonaught.inventorysorter.client.sort.plan.PlannedContainerClick;
 import net.kyrptonaught.inventorysorter.client.sort.plan.SlotState;
+import net.kyrptonaught.inventorysorter.sort.SortType;
+import net.kyrptonaught.inventorysorter.sort.SortedInventoryLayout;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentPatch;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 import static net.minecraft.core.component.DataComponents.ITEM_NAME;
 public class ClientSortClickPlannerTest {
@@ -173,6 +176,52 @@ public class ClientSortClickPlannerTest {
                 click(1)
         ), clicks.orElseThrow());
         assertClicksReachDesiredLayout(current, clicks.get(), desired);
+    }
+
+    @Test
+    void partialStacksCanMergeWhenTheirSortedTargetContainsAnotherItem() {
+        List<ItemStack> current = List.of(
+                stack(Items.APPLE, 1),
+                stack(Items.DIAMOND, 52),
+                stack(Items.DIAMOND, 1),
+                ItemStack.EMPTY
+        );
+        List<ItemStack> desired = List.of(
+                stack(Items.DIAMOND, 53),
+                stack(Items.APPLE, 1),
+                ItemStack.EMPTY,
+                ItemStack.EMPTY
+        );
+
+        Optional<List<PlannedContainerClick>> clicks = planner.plan(slots(current), desired);
+
+        Assertions.assertTrue(clicks.isPresent());
+        assertClicksReachDesiredLayout(current, clicks.get(), desired);
+    }
+
+    @Test
+    void variedPartialStackLayoutsAlwaysProduceAValidPlan() {
+        Random random = new Random(0x5EED);
+        List<Item> itemTypes = List.of(Items.APPLE, Items.CACTUS, Items.DIAMOND, Items.STICK);
+
+        for (int scenario = 0; scenario < 500; scenario++) {
+            List<ItemStack> current = new java.util.ArrayList<>();
+            int emptySlotsOutOfTen = scenario % 11;
+            for (int slot = 0; slot < 54; slot++) {
+                if (random.nextInt(10) < emptySlotsOutOfTen) {
+                    current.add(ItemStack.EMPTY);
+                } else {
+                    Item item = itemTypes.get(random.nextInt(itemTypes.size()));
+                    current.add(stack(item, 1 + random.nextInt(64)));
+                }
+            }
+            List<ItemStack> desired = SortedInventoryLayout.from(current, SortType.NAME, "en_us").stacks();
+
+            Optional<List<PlannedContainerClick>> clicks = planner.plan(slots(current), desired);
+
+            Assertions.assertTrue(clicks.isPresent(), "scenario " + scenario + " could not be planned");
+            assertClicksReachDesiredLayout(current, clicks.get(), desired);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What was happening

I ran into this on a Realm without server-side support. Some chests would not sort at all, even though smaller or slightly different layouts worked.

The smallest example uses name sorting:

    Before:   [Diamond x1] [Apple x1]   [Apple x1]
    Expected: [Apple x2]   [Diamond x1] [empty]

The fallback sorter tried to merge the apples directly into their final slot. Since the diamond was already in that slot, it gave up before sending any clicks. Putting an apple in the first slot made the same chest sort normally, which is why the bug seemed inconsistent.

## Fix

Partial stacks are now merged in a matching slot before the finished stacks are moved into sorted order.

I added a regression test for the example above and tested another 500 generated double-chest layouts at different fill levels. (Thank you Codex)

## Testing

- Ran `./gradlew buildActive`
- Tested on Minecraft 26.2 with Fabric
- Tested on a Realm without server-side support using several chests that previously would not sort

## Demo (sound on)

https://github.com/user-attachments/assets/e4f50735-7393-4016-a70f-82cb2427f0b3

